### PR TITLE
Enhanced data cleaning and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ When enabled, DataMorpher performs:
   - Date columns: Left as missing
   - Boolean columns: Mode
   - Invalid values reported for review
+- **Smart Parsing**: Extracts numbers from corrupted strings (e.g. `"8000foo0" -> 8000`)
+- **Date Formats**: Supports `%Y-%m-%d`, `%d/%m/%Y`, `%m/%d/%Y`, and `%Y/%m/%d`
 
 ## Conversion Report
 
@@ -105,6 +107,7 @@ Each conversion generates a Markdown report containing:
 - Values imputed per column
 - Detected data types
 - Total execution time
+- Detailed transformations of cleaned values
 
 Example report snippet:
 ```markdown
@@ -122,6 +125,15 @@ Example report snippet:
 - OrderDate: date
 - Amount: numeric
 - Status: categorical
+```
+
+The report also lists transformations applied, for example:
+
+```markdown
+## Transformations appliquées
+### Colonne 'salary'
+- "8000foo0" -> 8000 (nombre extrait)
+- NaN -> 76166.67 (mean)
 ```
 
 ## Development

--- a/datamorpher/reporter.py
+++ b/datamorpher/reporter.py
@@ -27,6 +27,8 @@ def build_report(
         "\n".join(f"- {c}: {m}" for c, m in clean_info["imputed"].items())
         or "None"
     )
+    transformations = clean_info.get("transformations", {})
+    invalid = clean_info.get("invalid", {})
     report = f"""# DataMorpher Report
 
 ## Summary
@@ -39,4 +41,14 @@ def build_report(
 ## Column Types
 {table}
 """
+    if transformations:
+        report += "\n\n## Transformations appliquées\n"
+        for col, changes in transformations.items():
+            report += f"### Colonne '{col}'\n"
+            for change in changes:
+                report += f"- {change}\n"
+            if invalid.get(col):
+                report += (
+                    f"- {invalid[col]} valeurs invalides non récupérables\n"
+                )
     return report

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -21,6 +21,18 @@ def test_numeric_and_date_validation() -> None:
     )
     cleaned, info = clean_data(df)
 
-    assert info["invalid"] == {"num": 1, "date": 1}
+    assert info["invalid"] == {"date": 1}
     assert cleaned.loc[1, "num"] == 28
+    assert cleaned.loc[2, "num"] == 8000
     assert cleaned["date"].isna().sum() == 1
+
+
+def test_date_format_variants() -> None:
+    df = pd.DataFrame(
+        {
+            "date": ["2020-01-02", "03/04/2021", "05/06/2022", "2020/07/08"],
+        }
+    )
+    cleaned, _ = clean_data(df)
+    expected = ["2020-01-02", "2021-04-03", "2022-06-05", "2020-07-08"]
+    assert list(cleaned["date"]) == expected

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -17,3 +17,24 @@ def test_report_contains_summary(tmp_path: Path) -> None:
     assert "DataMorpher Report" in report
     assert "in.csv" in report
     assert "out.csv" in report
+
+
+def test_report_includes_transformations(tmp_path: Path) -> None:
+    types = {"a": "integer"}
+    clean_info = {
+        "duplicates": 0,
+        "imputed": {"a": "mean"},
+        "invalid": {},
+        "transformations": {"a": ["1 -> 2"]},
+    }
+    report = build_report(
+        Path("in.csv"),
+        tmp_path / "out.csv",
+        1,
+        1,
+        clean_info,
+        types,
+        0.1,
+    )
+    assert "Transformations appliquées" in report
+    assert "1 -> 2" in report


### PR DESCRIPTION
## Summary
- track value transformations during cleaning
- parse corrupted numeric strings and multiple date formats
- report extracted values and invalid counts
- document supported date formats and transformation examples
- test new cleaning behaviour and report output

## Testing
- `ruff check .`
- `pytest -q`